### PR TITLE
This closes #5 issue with different result from login method call.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -38,8 +38,8 @@ BricksetClient._wrap = function _wrap(desc, fn) {
           username: username,
           password: password
         })
-          .then(function (userHash) {
-            this._opts.user_hash = userHash;
+          .then(function (loginResponse) {
+            this._opts.user_hash = loginResponse.loginResult;
             return call.call(this);
           }.bind(this));
       } else {

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -56,7 +56,7 @@ describe('BricksetClient', function () {
           port: {
             foo: sandbox.stub().returns(Q(true)),
             bar: sandbox.stub().returns(Q(true)),
-            login: sandbox.stub().returns(Q(user_hash))
+            login: sandbox.stub().returns(Q({loginResult : user_hash}))
           }
         }
       };


### PR DESCRIPTION
Currently login method returns object with {loginResult: userHash}, not pure userHash as expected in tests and code as mentioned in #5 