### PR TITLE
Accepts null userHash as param for method.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -27,7 +27,8 @@ BricksetClient._wrap = function _wrap(desc, fn) {
         },
         username,
         password;
-      if (!this._opts.user_hash) {
+      if (!this._opts.user_hash &&
+          typeof(params.userHash) === 'undefined') {
         username = params.username || this._opts.username;
         password = params.password || this._opts.password;
         if (!(username || password)) {

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -94,6 +94,15 @@ describe('BricksetClient', function () {
           .to.eventually.be.rejectedWith(config.errors.NO_USERNAME_OR_PASSWORD);
       });
 
+    it('should omit login if userHash defined even if API function requires auth',
+      function () {
+        return expect(bs.bar({userHash: null}))
+            .to.eventually.become(true)
+            .then(function () {
+              expect(client.service.port.login).to.have.been.not.called;
+            });
+      });
+
     it('should attempt login if API function requires auth',
       function () {
         return expect(bs.bar({


### PR DESCRIPTION
 Effectively overrides login check and call method for methods that have userHash as available input.

This will allow for use cases where method has optional userHash argument, without throwing missing login data info. 

This closes #8 